### PR TITLE
Fix: Ensure correct doctor specialty in bill API responses

### DIFF
--- a/app/Http/Resources/BillResource.php
+++ b/app/Http/Resources/BillResource.php
@@ -26,10 +26,12 @@ class BillResource extends JsonResource
                 ];
             }),
             'doctor' => $this->whenLoaded('doctor', function () {
+                 // $this->doctor here is the User model instance for the doctor
                 return [
                     'id' => $this->doctor->id,
-                    'name' => $this->doctor->name ?? 'Unknown',
-                    'specialty' => $this->doctor->doctor_profile->specialty ?? null,
+                    'name' => $this->doctor->name ?? 'Unknown Doctor', // Name is directly on the User model
+                    // Access specialty through the User's 'doctor' profile relationship
+                    'specialty' => $this->doctor->doctor ? $this->doctor->doctor->specialty : null,
                 ];
             }),
             'amount' => (float) $this->amount,

--- a/app/Services/BillService.php
+++ b/app/Services/BillService.php
@@ -60,10 +60,17 @@ class BillService
      * @param int $id
      * @return Bill|null
      */
-    public function getBillById(int $id): ?Bill
+    public function getBillById(int $id, array $relations = []): ?Bill
     {
-        return $this->billRepository->findById($id, ['patient', 'doctor', 'items']);
-    }
+        // Define default relations that are almost always needed for a single bill view
+    // Ensure 'doctor.doctor' is loaded to get the specialty from the Doctor model
+    $defaultRelations = ['patient.user', 'doctor.doctor', 'items'];
+    // Merge default relations with any additional specific relations requested
+    $allRelations = array_unique(array_merge($defaultRelations, $relations));
+    
+    return $this->billRepository->findById($id, $allRelations);
+}
+    
     
     /**
      * Create a new bill with its items


### PR DESCRIPTION
- Updated BillResource to correctly access doctor's specialty via the 'user->doctor->specialty' relationship.
- Modified BillService and BillController to eager load the 'doctor.doctor' relationship, ensuring the specialty data is efficiently fetched and available for bill-related API endpoints.