### PR TITLE
feat: sync User name with PersonalInfo name+surname

### DIFF
--- a/app/Observers/PersonalInfoObserver.php
+++ b/app/Observers/PersonalInfoObserver.php
@@ -1,0 +1,40 @@
+<?php
+// filepath: c:\Users\Microsoft\Documents\portail\admin_backend\app\Observers\PersonalInfoObserver.php
+
+namespace App\Observers;
+
+use App\Models\PersonalInfo;
+
+class PersonalInfoObserver
+{
+    /**
+     * Handle the PersonalInfo "created" event.
+     */
+    public function created(PersonalInfo $personalInfo): void
+    {
+        $this->syncUserName($personalInfo);
+    }
+
+    /**
+     * Handle the PersonalInfo "updated" event.
+     */
+    public function updated(PersonalInfo $personalInfo): void
+    {
+        // Vérifier si name ou surname ont changé
+        if ($personalInfo->wasChanged('name') || $personalInfo->wasChanged('surname')) {
+            $this->syncUserName($personalInfo);
+        }
+    }
+
+    /**
+     * Synchroniser le nom complet dans la table User
+     */
+    private function syncUserName(PersonalInfo $personalInfo): void
+    {
+        $fullName = trim($personalInfo->name . ' ' . $personalInfo->surname);
+        
+        if (!empty($fullName) && $personalInfo->patient && $personalInfo->patient->user) {
+            $personalInfo->patient->user->update(['name' => $fullName]);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,7 +16,8 @@ use App\Observers\AppointmentObserver;
 use Illuminate\Database\Connectors\PostgresConnector;
 use Illuminate\Support\Facades\Log;
 use PDO;
-
+use App\Models\PersonalInfo;
+use App\Observers\PersonalInfoObserver;
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -135,5 +136,8 @@ class AppServiceProvider extends ServiceProvider
                 }
             };
         });
+
+        PersonalInfo::observe(PersonalInfoObserver::class);
     }
+     
 }

--- a/app/Services/PersonalInfoService.php
+++ b/app/Services/PersonalInfoService.php
@@ -78,6 +78,29 @@ class PersonalInfoService
             unset($data['phone']); // Remove from personal info data
         }
 
+// ✅ NOUVEAU: Synchroniser le name complet dans User
+    if (isset($data['name']) || isset($data['surname'])) {
+        // Récupérer les valeurs actuelles de PersonalInfo
+        $currentPersonalInfo = $this->personalInfoRepository->getByPatientId($patient->id);
+        
+        $currentName = $currentPersonalInfo->name ?? '';
+        $currentSurname = $currentPersonalInfo->surname ?? '';
+        
+        // Utiliser les nouvelles valeurs ou garder les actuelles
+        $newName = $data['name'] ?? $currentName;
+        $newSurname = $data['surname'] ?? $currentSurname;
+        
+        // Construire le nom complet
+        $fullName = trim($newName . ' ' . $newSurname);
+         // Mettre à jour le User avec le nom complet
+        if (!empty($fullName)) {
+            $user->update(['name' => $fullName]);
+        }
+    }
+
+
+
+
         $personalInfo = $this->personalInfoRepository->updateOrCreateByPatientId($patient->id, $data);
 
         return new PersonalInfoResource($personalInfo->load(['patient.user']));
@@ -162,6 +185,30 @@ class PersonalInfoService
             $patient->user->update(['phone' => $data['phone']]);
             unset($data['phone']); // Remove from personal info data
         }
+
+// ✅ NOUVEAU: Synchroniser le name complet dans User
+    if (isset($data['name']) || isset($data['surname'])) {
+        // Récupérer les valeurs actuelles de PersonalInfo
+        $currentPersonalInfo = $this->personalInfoRepository->getByPatientId($patient->id);
+        
+        $currentName = $currentPersonalInfo->name ?? '';
+        $currentSurname = $currentPersonalInfo->surname ?? '';
+        
+        // Utiliser les nouvelles valeurs ou garder les actuelles
+        $newName = $data['name'] ?? $currentName;
+        $newSurname = $data['surname'] ?? $currentSurname;
+        
+        // Construire le nom complet
+        $fullName = trim($newName . ' ' . $newSurname);
+          // Mettre à jour le User avec le nom complet
+        if (!empty($fullName)) {
+            $patient->user->update(['name' => $fullName]);
+        }
+    }
+
+
+
+
         $personalInfo = $this->personalInfoRepository->updateOrCreateByPatientId($patient->id, $data);
 
         return new PersonalInfoResource($personalInfo->load(['patient.user']));

--- a/database/seeders/PatientSeeder.php
+++ b/database/seeders/PatientSeeder.php
@@ -136,7 +136,11 @@ class PatientSeeder extends Seeder
                 'created_at' => $registrationDate,
                 'updated_at' => $registrationDate,
             ]);
-            
+            // ✅ AJOUTER CETTE LIGNE: Synchroniser le nom dans User (même si déjà fait lors de la création)
+            // Ceci assure la cohérence pour les données futures quand name/surname changent
+            $user->update(['name' => $firstName . ' ' . $lastName]);
+
+
             $progressBar->advance();
         }
         

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,6 +108,7 @@ Route::group(['middleware' => ['jwt.auth']], function () {
     Route::get('activity-logs/actions', [ActivityLogController::class, 'getActions']);
     Route::get('activity-logs/modules', [ActivityLogController::class, 'getModules']);
 
+
     // Analytics Routes (with permission middleware)
     Route::group(['middleware' => 'permission:analytics:view'], function () {
         // Existing routes


### PR DESCRIPTION
- Add PersonalInfoObserver to automatically sync User.name when PersonalInfo name/surname changes
- Update PersonalInfoService to handle name synchronization in update methods
- Modify PatientSeeder to ensure consistent name data between User and PersonalInfo
- Register PersonalInfoObserver in AppServiceProvider
- Fix patient profile data consistency issue where User.name wasn't updated when patient's name/surname changed