### PR TITLE
fix(validation): Return JSON response on bill request validation failure

### DIFF
--- a/app/Http/Requests/Bill/StoreBillRequest.php
+++ b/app/Http/Requests/Bill/StoreBillRequest.php
@@ -3,7 +3,8 @@
 namespace App\Http\Requests\Bill;
 
 use Illuminate\Foundation\Http\FormRequest;
-
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 class StoreBillRequest extends FormRequest
 {
     /**
@@ -36,5 +37,21 @@ class StoreBillRequest extends FormRequest
             'items.*.description' => 'nullable|string',
             'items.*.price' => 'required|numeric|min:0',
         ];
+    }
+     /**
+     * Handle a failed validation attempt.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return void
+     *
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $validator->errors()
+        ], 422));
     }
 }

--- a/app/Http/Requests/Bill/UpdateBillRequest.php
+++ b/app/Http/Requests/Bill/UpdateBillRequest.php
@@ -5,7 +5,8 @@ namespace App\Http\Requests\Bill;
 use App\Models\Bill;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 class UpdateBillRequest extends FormRequest
 {
     /**
@@ -47,5 +48,21 @@ class UpdateBillRequest extends FormRequest
             'items.*.description' => 'nullable|string',
             'items.*.price' => 'required|numeric|min:0',
             ];
+    }
+      /**
+     * Handle a failed validation attempt.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return void
+     *
+     * @throws \Illuminate\Http\Exceptions\HttpResponseException
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => 'Validation errors',
+            'errors' => $validator->errors()
+        ], 422));
     }
 }


### PR DESCRIPTION
Previously, API requests for creating or updating a bill would result in a 302 redirect on validation failure, which is incorrect for an API.

This commit overrides the ailedValidation method in both StoreBillRequest and UpdateBillRequest to throw an HttpResponseException with a 422 status code. This ensures that API clients receive a proper JSON error object, improving client-side error handling.